### PR TITLE
add links to homepage PillarIcons

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -55,7 +55,7 @@ export default () => (
           <p>{homeJson.thirdSectionDescription}</p>
           <PillarRow>
             {homeJson.thirdSectionItems.map((pillar, i) => (
-              <PillarIcon key={i} background={pillar.background}>
+              <PillarIcon to={`/${pillar.title}`} key={i} background={pillar.background}>
                 <div>
                   <img alt={pillar.title} src={pillarIcons[pillar.title]} height="75" />
                   <h4>{pillar.title}</h4>

--- a/src/components/home/styles.js
+++ b/src/components/home/styles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { Link } from 'gatsby'
 
 export const ThreeStep = styled.section`
   background: rgb(240, 240, 240);
@@ -65,7 +66,7 @@ export const PillarRow = styled.aside`
   }
 `
 
-export const PillarIcon = styled.div`
+export const PillarIcon = styled(Link)`
   background: ${props => props.background};
   line-height: 2rem;
   border-radius: 1rem;
@@ -75,8 +76,13 @@ export const PillarIcon = styled.div`
   margin: auto;
   padding: 3rem;
   text-align: center;
+  text-decoration: none;
   display: grid;
   grid-template-rows: 1fr 1fr;
+  &:hover, &:focus {
+    box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+    transform: translate(-2px, -2px);
+  }
   @media (max-width: 990px) {
     padding: 1.5rem;
     grid-template-rows: 2fr 1fr;


### PR DESCRIPTION
**Changes:** Turns the pillar icons on the homepage into links to their respective pages.

![pillar-link-education-hover](https://user-images.githubusercontent.com/13618860/52835752-aacb6a80-309c-11e9-9c81-4dcd332f721d.png)