### PR TITLE
#63 fix event details modal 

### DIFF
--- a/src/components/calendar/details.js
+++ b/src/components/calendar/details.js
@@ -2,7 +2,6 @@ import React from "react"
 import { Link } from "gatsby"
 import moment from "moment"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-
 import truncateString from "Utils/truncate"
 import { StyledDetails } from "./styles"
 
@@ -45,6 +44,7 @@ function Details({ eventInfo, setEventInfo, ...position }) {
         </div>
         <span>
           <button
+            className="close-details"
             type="button"
             onClick={() => setEventInfo(null)}
           >

--- a/src/components/calendar/styles.js
+++ b/src/components/calendar/styles.js
@@ -37,8 +37,8 @@ export const StyledDetails = styled.aside`
     }
     .close-details {
         color: rgba(255, 255, 255, 0.5);
-        padding: 5px;
-        padding-left: 20px;
+        margin-left: 15px;
+        padding: 5px 10px;
         &:hover {
           color: white;
           cursor: pointer;

--- a/src/components/calendar/styles.js
+++ b/src/components/calendar/styles.js
@@ -35,10 +35,20 @@ export const StyledDetails = styled.aside`
       background: none;
       color: white;
     }
+    .close-details {
+        color: rgba(255, 255, 255, 0.5);
+        padding: 5px;
+        padding-left: 20px;
+        &:hover {
+          color: white;
+          cursor: pointer;
+        }
+      }
   }
   .content {
     font-size: 1.2rem;
     padding: 1.6rem;
     text-align: left;
   }
+
 `

--- a/src/components/events/index.js
+++ b/src/components/events/index.js
@@ -1,6 +1,5 @@
 import React from "react"
 import PropTypes from "prop-types"
-
 import ExternalLink from "Common/ExternalLink"
 import { MAPS_URL } from "Utils/constants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -9,7 +8,6 @@ import Modal from "react-modal"
 import moment from "moment"
 import styled from "styled-components"
 import urlencode from "urlencode"
-
 import truncateString from "Utils/truncate"
 import ProposeEvent from "Components/forms/propose-event"
 


### PR DESCRIPTION
*Changes:*
- Add margin-left 15px to close button
- Padding changed to 5px top/bottom 10px left/right
- close button on hover 
   - color change
   - cursor-pointer

![eventModalClose](https://user-images.githubusercontent.com/35650608/54076243-53b15380-425e-11e9-8273-30a8b24c21db.jpg)

Fixes #63 