### PR TITLE
#76 fix pillar template styling and center text on mobile

### DIFF
--- a/src/components/layout/styles.js
+++ b/src/components/layout/styles.js
@@ -22,7 +22,7 @@ export const Wrapper = styled.div`
     color: ${props => props.theme.gray};
 
     @media(max-width: 450px) {
-      width: 100vw !important;
+      width: 90vw !important;
     }
   }
   section:first-child {

--- a/src/components/pillars/styles.js
+++ b/src/components/pillars/styles.js
@@ -41,9 +41,7 @@ export const PillarInfo = styled.section`
 export const PillarSection = styled.section`
   @media(max-width: 450px) {
     padding: 10px;
-    h2 {
-      text-align: center;
-    }
+    text-align: center;
   }
 `
 


### PR DESCRIPTION
*Changes*

- Changed width: 100vw to 90vw in layouts > styles.js
- Added text-align: center to media query max-width 450px in pillars > styles.js

![pillermarginfix](https://user-images.githubusercontent.com/35650608/54552719-fc9e3380-496d-11e9-9030-c53d79381962.jpg)
