### PR TITLE
Fix #125 mobile menu tab highlight 

### DIFF
--- a/src/components/layout/nav/burger.css
+++ b/src/components/layout/nav/burger.css
@@ -1,6 +1,6 @@
 /* Position and sizing of burger button */
 .bm-burger-button {
-  position: fixed;
+ position: fixed; 
   width: 36px;
   height: 30px;
   right: 36px;
@@ -65,6 +65,7 @@ Note: Beware of modifying this element as it can break the animations - you shou
 /* Individual item */
 .bm-item {
   display: inline-block;
+  outline: none;
 }
 
 /* Styling of overlay */

--- a/src/components/layout/nav/burger.css
+++ b/src/components/layout/nav/burger.css
@@ -1,6 +1,6 @@
 /* Position and sizing of burger button */
 .bm-burger-button {
- position: fixed; 
+  position: fixed;
   width: 36px;
   height: 30px;
   right: 36px;


### PR DESCRIPTION
*Changes*

- added outline: none to .bm-item in src/components/layout/nav/burger.css
 
![mobile tab](https://user-images.githubusercontent.com/35650608/55675215-08e22600-5874-11e9-83b5-159063fd5250.jpg)


Fixes #125 