### PR TITLE
Add visual regression testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,8 @@ module.exports = {
   },
   globals: {
     alert: "readonly",
+    browser: true,
+    context: true,
     document: "readonly",
     fetch: "readonly",
     FormData: "readonly",
@@ -54,6 +56,7 @@ module.exports = {
     location: "readonly",
     navigator: "readonly",
     Notification: "readonly",
+    page: true,
     window: "readonly",
     __PATH_PREFIX__: true,
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-if (process.env.LOCAL_BUILD || process.env.NODE_ENV === "development") {
+if (process.env.LOCAL_BUILD || process.env.NODE_ENV !== "production") {
   require("dotenv").config({ path: ".env.dev" })
 }
 
@@ -72,7 +72,7 @@ const plugins = [
       entities: ["events", "venues"],
     },
   },
-  "gatsby-plugin-netlify-cms"
+  "gatsby-plugin-netlify-cms",
 ]
 
 if (process.env.NODE_ENV === "production") {
@@ -106,7 +106,7 @@ const config = {
       "San Diego Tech Hub represents a movement aimed at changing the perception of the San Diego tech ecosystem. Our focus is to be a conduit for change connecting businesses, organizations, and individuals, leveraging their resources and talents to build a stronger San Diego tech community through collaboration.",
     author: "Claude Jones",
     twitterHandle: "@SanDiegoTechHub",
-    image: "https://www.SanDiegoTechHub.com/circle-logo.png"
+    image: "https://www.SanDiegoTechHub.com/circle-logo.png",
   },
   plugins,
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  server: {
+    command: "gatsby develop",
+    launchTimeout: 25000,
+    port: 8000,
+    debug: true,
+  },
+}

--- a/jest.visual.config.js
+++ b/jest.visual.config.js
@@ -1,0 +1,39 @@
+module.exports = {
+  preset: "jest-puppeteer",
+  globals: {
+    __PATH_PREFIX__: "",
+  },
+  moduleFileExtensions: [
+    "js", "jsx", "json",
+  ],
+  moduleNameMapper: {
+    ".+\\.(css|styl|less|sass|scss)$": "identity-obj-proxy",
+    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/file-mock.js",
+    "^Components/(.*)$": "<rootDir>/src/components/$1",
+    "^Common/(.*)$": "<rootDir>/src/components/common/$1",
+    "^Test/(.*)$": "<rootDir>/test-env/$1",
+    "^Utils/(.*)$": "<rootDir>/src/utils/$1",
+  },
+  setupFiles: [
+    "<rootDir>/test-env/loadershim.js",
+  ],
+  setupFilesAfterEnv: [
+    "<rootDir>/test-env/setup-test-env.js",
+  ],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/.cache/",
+    "<rootDir>/public/",
+  ],
+  testRegex: "(visualtest|visualspec)\\.[jt]sx?$",
+  testURL: "http://localhost",
+  transform: {
+    "^.+\\.jsx?$": "<rootDir>/test-env/jest-preprocess.js",
+  },
+  transformIgnorePatterns: ["node_modules/(?!(gatsby)/)"],
+  watchPathIgnorePatterns: [
+    "<rootDir>/node_modules/",
+    "<rootDir>/.cache/",
+    "<rootDir>/public/",
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "clearCache": "rm -rf ./.cache",
     "serve": "gatsby serve",
     "start": "gatsby develop",
-    "test": "jest --watchAll"
+    "test": "jest --watchAll",
+    "test:visual": "jest -c jest.visual.config.js --runInBand"
   },
   "husky": {
     "hooks": {
@@ -110,7 +111,10 @@
     "jest": "^24.3.1",
     "jest-dom": "^3.1.2",
     "jest-fetch-mock": "^2.1.1",
+    "jest-image-snapshot": "^2.8.1",
+    "jest-puppeteer": "^4.1.0",
     "lint-staged": "^8.1.4",
+    "puppeteer": "^1.14.0",
     "react-testing-library": "^6.0.0"
   },
   "license": "MIT"

--- a/src/__visualtests__/404.visualtest.js
+++ b/src/__visualtests__/404.visualtest.js
@@ -1,0 +1,14 @@
+const { port } = require("../../jest-puppeteer.config").server
+
+const url = `http://localhost:${port}/404`
+
+describe("404 page", () => {
+  beforeAll(async () => {
+    await page.goto(`${url}`)
+  })
+
+  it("works", async () => {
+    const image = await page.screenshot()
+    expect(image).toMatchImageSnapshot()
+  })
+})

--- a/src/__visualtests__/index.visualtest.js
+++ b/src/__visualtests__/index.visualtest.js
@@ -1,0 +1,14 @@
+const { port } = require("../../jest-puppeteer.config").server
+
+const url = `http://localhost:${port}`
+
+describe("Home page", () => {
+  beforeAll(async () => {
+    await page.goto(`${url}`)
+  })
+
+  it("works", async () => {
+    const image = await page.screenshot()
+    expect(image).toMatchImageSnapshot()
+  })
+})

--- a/test-env/setup-test-env.js
+++ b/test-env/setup-test-env.js
@@ -6,3 +6,10 @@ import "react-testing-library/cleanup-after-each"
 import MockFetch from "jest-fetch-mock"
 
 global.fetch = MockFetch
+
+// Setup for visual testing
+require("expect-puppeteer")
+const { toMatchImageSnapshot } = require("jest-image-snapshot")
+
+expect.extend({ toMatchImageSnapshot })
+jest.setTimeout(25000)


### PR DESCRIPTION
- Set up [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer) and [`jest-image-snapshot`](https://github.com/americanexpress/jest-image-snapshot) for visual testing
- Type `npm run test:visual` to run visual tests, screenshots will be stored in `__image_snapshots__` folder in the same directory as the test files
- Closes #108 

#### Packages added:
- `jest-puppeteer`
- `jest-image-snapshot`
- `puppeteer`

#### New files:
- `jest.visual.config.js` - Jest config for visual testing (only looks for `.visualtest.js` or `.visualspec.js` files)
- `jest-puppeteer.config.js` - Jest puppeteer config
- `404.visualtest.js` - Visual test for 404 page
- `index.visualtest.js` - Visual test for home page

#### Modified files:
- `.eslintrc.js` - Added `browser`, `context`, and `page` global variables
- `setup-test-env.js` - Extended `expect` with `toMatchImageSnapshot`, increased jest timeout to 25000
- `package.json` - Added `test:visual` script for running visual tests only

### Issues:
- Visual test snapshots are blank images