### PR TITLE
Adds filtering to network search results

### DIFF
--- a/src/components/network/SearchBar.js
+++ b/src/components/network/SearchBar.js
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
-const SearchBar = () => (
+const SearchBar = ({ setFilterText }) => (
   <Container>
     <BookEnd />
     <Selector>
@@ -12,7 +12,7 @@ const SearchBar = () => (
         <option value="3">Mentors</option>
       </select>
     </Selector>
-    <Search type="text" />
+    <Search type="text" onChange={setFilterText} />
   </Container>
 )
 

--- a/src/components/network/SearchBar.js
+++ b/src/components/network/SearchBar.js
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
-const SearchBar = ({ setFilterText }) => (
+const SearchBar = ({ filterText, setFilterText }) => (
   <Container>
     <BookEnd />
     <Selector>
@@ -12,7 +12,7 @@ const SearchBar = ({ setFilterText }) => (
         <option value="3">Mentors</option>
       </select>
     </Selector>
-    <Search type="text" onChange={setFilterText} />
+    <Search type="text" onChange={setFilterText} value={filterText} />
   </Container>
 )
 

--- a/src/components/network/SearchResults.js
+++ b/src/components/network/SearchResults.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import Resources from "./resources"
 
-export default function SearchResults({ results }) {
+export default function SearchResults({ results, filterText }) {
   const resourceType = Object.keys(results)[0]
   const ResourceCard = Resources[resourceType]
   const resultList = results[resourceType]
@@ -11,6 +11,7 @@ export default function SearchResults({ results }) {
     <Container>
       <ResultList>
         {resultList
+          .filter(resource => resource.name.toLowerCase().includes(filterText.toLowerCase()))
           .map(resource => <ResourceCard {...resource} key={resource.id} />)
         }
       </ResultList>

--- a/src/components/network/index.js
+++ b/src/components/network/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import styled from "styled-components"
 import { NAV_HEIGHT } from "Utils/constants"
@@ -7,14 +7,15 @@ import SearchResults from "./SearchResults"
 
 export default function Network() {
   const { hasura } = useStaticQuery(hasuraQuery)
+  const [filterText, setFilterText] = useState("")
 
   return (
     <Container>
       <Header>
         <Title>Network</Title>
-        <SearchBar />
+        <SearchBar setFilterText={e => setFilterText(e.target.value)} filterText={filterText} />
       </Header>
-      <SearchResults results={hasura} />
+      <SearchResults results={hasura} filterText={filterText} />
     </Container>
   )
 }

--- a/src/components/network/index.js
+++ b/src/components/network/index.js
@@ -13,7 +13,10 @@ export default function Network() {
     <Container>
       <Header>
         <Title>Network</Title>
-        <SearchBar setFilterText={e => setFilterText(e.target.value)} filterText={filterText} />
+        <SearchBar
+          filterText={filterText}
+          setFilterText={e => setFilterText(e.target.value)}
+        />
       </Header>
       <SearchResults results={hasura} filterText={filterText} />
     </Container>


### PR DESCRIPTION
This uses a React hook to add filtering to results on
the Network page.

Fixes #153

Looks like hooks was the way to go.

![filtering-complete](https://user-images.githubusercontent.com/23508546/61612852-827c0500-ac14-11e9-8f66-e6de69a6c47f.gif)
