### PR TITLE
Adds code school map on network page

### DIFF
--- a/src/components/network/index.js
+++ b/src/components/network/index.js
@@ -18,6 +18,12 @@ export default function Network() {
           setFilterText={e => setFilterText(e.target.value)}
         />
       </Header>
+      <iframe
+        title="Code Schools"
+        src="https://www.google.com/maps/d/u/0/embed?mid=1umjck4O4CFh8XjLqskK0Xb2NeAehDS70&z=10"
+        width="100%"
+        height="300px"
+      />
       <SearchResults results={hasura} filterText={filterText} />
     </Container>
   )


### PR DESCRIPTION
Adds a map of code schools to the network page.

Fixes #155

Desktop:
![image](https://user-images.githubusercontent.com/23508546/61681392-266fba00-acc2-11e9-96eb-34970506e2b7.png)



Mobile:
![image](https://user-images.githubusercontent.com/23508546/61681359-1061f980-acc2-11e9-97b0-68c414730b6e.png)
