### PR TITLE
add dynamic google map with pins that filter via searchbar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "import/no-cycle": 0,
     "import/no-dynamic-require": 0,
     "import/no-extraneous-dependencies": 0,
+    "import/no-named-as-default": 0,
     "import/no-unresolved": 0,
     "import/no-useless-path-segments": 0,
     "import/no-webpack-loader-syntax": 0,

--- a/src/components/network/GoogleMap.js
+++ b/src/components/network/GoogleMap.js
@@ -1,25 +1,48 @@
-import React from "react"
-import styled from "styled-components"
+import React, { Component } from "react"
+import { Map, GoogleApiWrapper, Marker } from "google-maps-react"
 
-export default function GoogleMap({ resourceType }) {
-  let id
-  if (resourceType === "codeSchool") {
-    id = "1umjck4O4CFh8XjLqskK0Xb2NeAehDS70&z=10"
-  } else if (resourceType === "venue") {
-    id = "1YlOiAqHsgnOPHNZUzCaoyQhYBDbzWlrV"
-  } else {
-    return null
+export class GoogleMap extends Component {
+  displayMarkers = () => {
+    const { results, resourceType, filterText } = this.props
+    const resultList = results[resourceType]
+    const filteredResults = (resultList || [])
+      .filter(resource => resource.name.toLowerCase().includes(filterText.toLowerCase()))
+    return filteredResults.map((result, index) => {
+      if (result.coordinates != null) {
+        return (
+          <Marker key={result.id}
+            id={index}
+            position={{
+              lat: result.coordinates[0],
+              lng: result.coordinates[1]
+            }}
+          />
+        )
+      }
+      return null
+    })
   }
-  return (
-    <IFrame
-        title="Code Schools"
-        src={`https://www.google.com/maps/d/u/0/embed?mid=${id}`}
-        width="100%"
-        height="300px"
-    />
-  )
+
+  render() {
+    const { google } = this.props
+    return (
+      <Map
+          google={google}
+          zoom={8}
+          style={mapStyles}
+          initialCenter={{ lat: 32.7157, lng: -117.1611 }}
+      >
+        {this.displayMarkers()}
+      </Map>
+    )
+  }
 }
 
-const IFrame = styled.iframe`
-  margin-bottom: 0;
-`
+export default GoogleApiWrapper({
+  apiKey: process.env.GATSBY_GOOGLE_MAPS_API_KEY
+})(GoogleMap)
+
+const mapStyles = {
+  width: "100%",
+  height: "300px"
+}

--- a/src/components/network/index.js
+++ b/src/components/network/index.js
@@ -23,7 +23,13 @@ export default function Network() {
           setResourceType={e => setResourceType(e.target.value)}
         />
       </Header>
-      <GoogleMap resourceType={resourceType} />
+      <MapContainer>
+        <GoogleMap
+        filterText={filterText}
+        resourceType={resourceType}
+        results={{ [resourceType]: results }}
+        />
+      </MapContainer>
       <SearchResults
         filterText={filterText}
         results={{ [resourceType]: results }}
@@ -45,6 +51,7 @@ const hasuraQuery = graphql`
         imageUrl
         socialMedia
         website
+        coordinates
       }
       venue {
         address
@@ -60,6 +67,7 @@ const hasuraQuery = graphql`
         name
         socialMedia
         website
+        coordinates
       }
       jobCandidate {
         name
@@ -98,6 +106,11 @@ const Container = styled.main`
   margin: ${NAV_HEIGHT} auto;
   padding: 0;
   width: 100vw;
+}
+`
+
+const MapContainer = styled.div`
+  margin-bottom: 320px;
 }
 `
 


### PR DESCRIPTION
Creates a dynamic map that places pins on the map based on coordinates in GraphQL database. Typing in the search-bar will also filter the pins on the map so the only pins shown are associated with the search results shown below the map. GPS coordinates must be added into the GraphQL database in the "coordinates" row of the appropriate table for the pin to show up on the map. To make this code functional GATSBY_GOOGLE_MAPS_API_KEY needs to be added as an environment variable and its value needs to be a valid google-maps api key (note: this may incur charges to the billing account associated with that api key, however google provides a $200 credit every month that should cover about the first 28k calls per month, so unless the site is experiencing more traffic than that per month it won't charge anything. see https://cloud.google.com/maps-platform/pricing/sheet/ for more details)